### PR TITLE
Fix cyclic graphs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/src/Components/Block.tsx
+++ b/src/Components/Block.tsx
@@ -20,7 +20,6 @@ export default class Block extends React.Component<BlockProps, {}> {
         style={{backgroundColor: this.props.color}}
         onClick={this.props.onClick}
       >
-      {this.props.coordinates[0]},{this.props.coordinates[1]}
       </div>
     );
   }

--- a/src/Components/Block.tsx
+++ b/src/Components/Block.tsx
@@ -4,6 +4,7 @@ import './Block.css';
 
 export interface BlockProps {
   color: Color;
+  coordinates: number[];
   onClick: () => void;
 }
 
@@ -18,7 +19,9 @@ export default class Block extends React.Component<BlockProps, {}> {
         className="board-block"
         style={{backgroundColor: this.props.color}}
         onClick={this.props.onClick}
-      />
+      >
+      {this.props.coordinates[0]},{this.props.coordinates[1]}
+      </div>
     );
   }
 }

--- a/src/Components/Grid.tsx
+++ b/src/Components/Grid.tsx
@@ -16,7 +16,7 @@ export default class Grid extends React.Component<
 
   constructor() {
     super();
-    this.board = new Board(20);
+    this.board = new Board(8);
     this.boardBuilder = new BoardBuilder(this.board);
     this.updateBoard = this.updateBoard.bind(this);
 

--- a/src/Components/Grid.tsx
+++ b/src/Components/Grid.tsx
@@ -9,15 +9,23 @@ import { NodeInterface } from '../lib/Node';
 export default class Grid extends React.Component<{}, {board: Map<String, NodeInterface>}> {
   private board: Board;
   private boardBuilder: BoardBuilder;
+  private runAll = true;
 
   constructor() {
     super();
     this.board = new Board(8);
     this.boardBuilder = new BoardBuilder(this.board); 
+    this.updateBoard = this.updateBoard.bind(this);
+
+    if (this.runAll) {
+      while (!this.boardBuilder.completed) {
+        this.boardBuilder.traverseStep();
+      }
+    }
+
     this.state = {
       board: this.board.state
     };
-    this.updateBoard = this.updateBoard.bind(this);
   }
 
   updateBoard() {

--- a/src/Components/Grid.tsx
+++ b/src/Components/Grid.tsx
@@ -6,15 +6,18 @@ import BoardBuilder from '../lib/BoardBuilder';
 
 import { NodeInterface } from '../lib/Node';
 
-export default class Grid extends React.Component<{}, {board: Map<String, NodeInterface>}> {
+export default class Grid extends React.Component<
+  {},
+  { board: Map<String, NodeInterface> }
+> {
   private board: Board;
   private boardBuilder: BoardBuilder;
   private runAll = true;
 
   constructor() {
     super();
-    this.board = new Board(8);
-    this.boardBuilder = new BoardBuilder(this.board); 
+    this.board = new Board(20);
+    this.boardBuilder = new BoardBuilder(this.board);
     this.updateBoard = this.updateBoard.bind(this);
 
     if (this.runAll) {
@@ -24,35 +27,40 @@ export default class Grid extends React.Component<{}, {board: Map<String, NodeIn
     }
 
     this.state = {
-      board: this.board.state
+      board: this.board.state,
     };
   }
 
   updateBoard() {
     this.boardBuilder.traverseStep();
     this.setState({
-      board: this.board.state
+      board: this.board.state,
     });
   }
 
   render() {
     const tiles = Array.from(this.state.board.values());
-    const tileArray = Array.from(new Array(this.board.size).keys()).map(el => tiles.splice(0, this.board.size));
+    const tileArray = Array.from(new Array(this.board.size).keys()).map(el =>
+      tiles.splice(0, this.board.size),
+    );
     return (
       <div className="board-grid">
-        {
-          tileArray.map((row, i) => {
-            return (
-              <div className="board-row" key={i}>
-                {row.map((node, j) => {
-                  return (
-                    <Block color={node.color} key={j} onClick={this.updateBoard} />
-                  );
-                })}
-              </div>
-            );
-          })
-        }
+        {tileArray.map((row, i) => {
+          return (
+            <div className="board-row" key={i}>
+              {row.map((node, j) => {
+                return (
+                  <Block
+                    color={node.color}
+                    coordinates={node.coordinates}
+                    key={j}
+                    onClick={this.updateBoard}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/src/lib/BoardBuilder.ts
+++ b/src/lib/BoardBuilder.ts
@@ -19,9 +19,11 @@ export default class BoardBuilder {
 
   public traverseStep() {
     if (!this.completed) {
-      console.log('at node: ', this.currIndex);
-      this.markNode();
+      console.log('at node: ', `${this.currIndex}`);
+      this.processNode();
       this.setNextIndex();
+    } else {
+      console.log('board complete, nothing to do');
     }
   }
 
@@ -39,17 +41,42 @@ export default class BoardBuilder {
     this.currIndex = idx;
   }
 
-  private markNode(): void {
+  private processNode(): void {
     console.log('analyzing node: ', this.currIndex);
     if (this.canBeMarked(this.currIndex)) {
       const node = this.board.nodeAt(this.currIndex);
-      if (this.isNode(node)) {
+      this.isNode(node) && this.markNode(node);
+    }
+  }
 
-        node.marked = true;
-        node.color = Color.Black;
-        if (this.isWallAdjacent(this.currIndex) || this.wallingNeigbhors(this.currIndex).length > 0) {
-          this.wallNeigbhors(this.currIndex);
-        }
+  private markNode(node: NodeInterface): void {
+    node.marked = true;
+    node.color = Color.Black;
+
+    // propagate walled status
+    if (
+      this.isWallAdjacent(this.currIndex) ||
+      this.wallingNeigbhors(this.currIndex).length > 0
+    ) {
+      this.wallNeigbhors(this.currIndex);
+    }
+
+    // propagate same id to indicate graph connectivity
+    this.propagateId(this.currIndex);
+  }
+
+  private propagateId(coordinates: number[]): void {
+    const node = this.board.nodeAt(this.currIndex);
+    if (this.isNode(node)) {
+      const adjacent = this.vertexNeigbhors(coordinates).filter(n => n.marked);
+
+      if (adjacent.length) {
+        const refId = adjacent[0].id;
+        node.id = refId;
+
+        adjacent
+          .filter(el => el.id !== refId)
+          .map(currNode => this.propagateId(currNode.coordinates));
       }
     }
   }
@@ -57,11 +84,11 @@ export default class BoardBuilder {
   private wallNeigbhors(nodeLoc: number[]): void {
     const node = this.board.nodeAt(nodeLoc);
     if (this.isNode(node)) {
-      console.log('WALLING this node', node)
+      console.log('WALLING this node', node);
       node.walled = true;
     }
 
-    console.log('and WALLING its neigbhors')
+    console.log('and WALLING its neigbhors');
     this.vertexNeigbhors(nodeLoc)
       .filter(n => n.marked)
       .map(n => {
@@ -72,21 +99,31 @@ export default class BoardBuilder {
       });
   }
 
-  private canBeMarked([x, y]: number[]): boolean {
-    const hasMarkedNeigbhors = this.hasMarkedNeigbhors([x, y]);
-    const isWalling = this.isWalling([x, y]);
+  private canBeMarked(coordinates: number[]): boolean {
+    const hasMarkedNeigbhors = this.hasMarkedNeigbhors(coordinates);
+    const isWalling = this.isWalling(coordinates);
+    const uniqueIdNeigbhors = this.uniqueIDNeigbhors(coordinates);
+
     console.log('hasMarkedNeigbhors:', hasMarkedNeigbhors);
     console.log('wallingNeigbhors', this.wallingNeigbhors(this.currIndex));
+    console.log('uniqueIdNeigbhors', uniqueIdNeigbhors);
     console.log('iswalling :', isWalling);
 
-    return !this.hasMarkedNeigbhors([x, y])
-      && !this.isWalling([x, y])
-      && Math.random() > 0.5;
+    return (
+      !this.hasMarkedNeigbhors(coordinates) &&
+      !this.isWalling(coordinates) &&
+      this.uniqueIDNeigbhors(coordinates) &&
+      Math.random() > 0.5
+    );
   }
 
   private isWallAdjacent([x, y]: number[]): boolean {
-    return x === 0 || (x === this.board.size - 1)
-      || y === 0 || (y === this.board.size - 1);
+    return (
+      x === 0 ||
+      x === this.board.size - 1 ||
+      y === 0 ||
+      y === this.board.size - 1
+    );
   }
 
   private vertexNeigbhors([x, y]: number[]): NodeInterface[] {
@@ -96,11 +133,13 @@ export default class BoardBuilder {
   }
 
   private uniqueIDNeigbhors(coordinates: number[]): boolean {
-    // TODO implement this function, then use algo to make sure no closed cycles
     const vertexAdjacent = this.vertexNeigbhors(coordinates);
-    return vertexAdjacent
-      .map(el => el.id)
-      .filter((val, index, s) => );
+    return (
+      vertexAdjacent
+        .map(el => el.id)
+        .filter((val, index, s) => s.indexOf(val) === index).length ===
+      vertexAdjacent.length
+    );
   }
 
   private wallingNeigbhors(coordinates: number[]): NodeInterface[] {
@@ -109,8 +148,10 @@ export default class BoardBuilder {
 
   private isWalling(coordinates: number[]): boolean {
     const wallingNeigbhorCount = this.wallingNeigbhors(coordinates).length;
-    return wallingNeigbhorCount >= 2 ||
-      this.isWallAdjacent(coordinates) && wallingNeigbhorCount > 0;
+    return (
+      wallingNeigbhorCount >= 2 ||
+      (this.isWallAdjacent(coordinates) && wallingNeigbhorCount > 0)
+    );
   }
 
   private hasMarkedNeigbhors([x, y]: number[]): boolean {
@@ -123,6 +164,6 @@ export default class BoardBuilder {
   }
 
   private isNode(maybeNode: NodeInterface | void): maybeNode is NodeInterface {
-    return (<NodeInterface> maybeNode) !== undefined;
+    return <NodeInterface>maybeNode !== undefined;
   }
 }


### PR DESCRIPTION
The previous solution wasn't respecting the rule of no cyclic graphs, nor any vertex graph of tiles that divide the white plane area into two or more areas. This fixes that bug and is performant for pretty large boards. Making them look okay is another matter altogether :). 